### PR TITLE
Update Prepare task to create tags for 1 week from today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.1.5
+- Update prepare task to tag release for 1 week from current day
+
 ### 0.1.4
 - Adding deploy branch preparation
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ without pushing it to the remote and creating it locally
 2.  Execute `prepare` using Bundler
     - Example: `bundle exec prepare`
     - This will create and push a branch using the agreed upon branch naming convention (`deploy-YYYYDDMM`) where `YYYYDDMM` refers to the _deployment_ date, not the date on which the branch is created.
-    - NOTE:  If no script parameters are specified, the script assumes the deployment date will be the upcoming Thursday relative to the day on which the branch is created.  For example, if the branch is created on Tuesday, April 3 2018, a branch named `deploy-20180405` will be created.
+    - NOTE:  If no script parameters are specified, the script assumes the deployment date will be the one week from the day on which the branch is created.  For example, if the branch is created on Thursday, August 22, 2019, a branch named `deploy-20190829` will be created.
 
 ### Options
 

--- a/bin/prepare
+++ b/bin/prepare
@@ -6,8 +6,7 @@ begin
   if ARGV[0]
     release_date = Date.parse ARGV[0]
   else
-    release_date = Date.today
-    release_date = release_date.next until release_date.thursday?
+    release_date = Date.today + 7
   end
 
   release_date = release_date.strftime('%Y%m%d')

--- a/bin/prepare
+++ b/bin/prepare
@@ -6,7 +6,8 @@ begin
   if ARGV[0]
     release_date = Date.parse ARGV[0]
   else
-    release_date = Date.today + 7
+    release_date = Date.tomorrow
+    release_date = release_date.next until release_date.thursday?
   end
 
   release_date = release_date.strftime('%Y%m%d')

--- a/lib/benchprep_tagster/version.rb
+++ b/lib/benchprep_tagster/version.rb
@@ -1,5 +1,5 @@
 module Benchprep
   module Tagster
-    VERSION = "0.1.4"
+    VERSION = "0.1.5"
   end
 end


### PR DESCRIPTION
Updates the `prepare` task to create the release branches 1 week from today.  

When creating the release branches EOD on the Thursday before the release, the current day would automatically be selected.